### PR TITLE
Update DamjesaP license to v2.1 with Polish translation

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -30,37 +30,3 @@ Copyleft 2025 rev. Damjes
 
 Ĉi tiu teksto mem estas libera sub la sama permesilo.
 
----
-
-_Ten tekst to oficjalne tłumaczenie na język polski. Obowiązujący jest oryginał w Esperanto (plik `LICENSE.md`)._
-
-# DamjesaP – Licencja Damjesa v. 2.1
-
-1. Każdy użytkownik ma cztery podstawowe wolności, którymi może się cieszyć bezterminowo na całym świecie:
-
-    0. Wolność używania utworu w dowolnym celu.
-
-    1. Wolność badania, jak utwór działa, oraz zmieniania go zgodnie ze swoimi potrzebami.
-       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
-
-    2. Wolność rozpowszechniania kopii, aby użytkownik mógł, na przykład, pomóc swojemu sąsiadowi.
-
-    3. Wolność ulepszania utworu i dzielenia się własnymi ulepszeniami ze wszystkimi.
-       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
-
-2. Nikt nie ma prawa unieważnić ani ograniczyć żadnej z powyższych wolności wobec kogokolwiek, w tym ograniczyć tych praw terytorialnie lub geograficznie.
-
-3. Nikt nie ma prawa zezwolić, by w dziełach pochodnych
-   te wolności zostały unieważnione lub ograniczone komukolwiek.
-
-4. Dzieła pochodne muszą jasno wskazywać, czy są powiązane, czy niepowiązane z autorem oryginału,
-   między innymi poprzez wzmiankę o nazwisku autora oryginału oraz ewentualną zmianę nazwy i marki.
-
-5. Utwór jest udostępniany _tak, jak jest_, bez jakiejkolwiek gwarancji wyraźnej lub dorozumianej.
-   Użytkownik korzysta z utworu na własne ryzyko.
-
----
-
-Copyleft 2025 wiel. Damjes
-
-Ten tekst sam w sobie jest wolny i może być rozpowszechniany na tych samych warunkach.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,3 +29,38 @@ DamjesaP – Damjesa Permesilo v. 2.1
 Copyleft 2025 rev. Damjes
 
 Ĉi tiu teksto mem estas libera sub la sama permesilo.
+
+---
+
+_Ten tekst to oficjalne tłumaczenie na język polski. Obowiązujący jest oryginał w Esperanto (plik `LICENSE.md`)._
+
+# DamjesaP – Licencja Damjesa v. 2.1
+
+1. Każdy użytkownik ma cztery podstawowe wolności, którymi może się cieszyć bezterminowo na całym świecie:
+
+    0. Wolność używania utworu w dowolnym celu.
+
+    1. Wolność badania, jak utwór działa, oraz zmieniania go zgodnie ze swoimi potrzebami.
+       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
+
+    2. Wolność rozpowszechniania kopii, aby użytkownik mógł, na przykład, pomóc swojemu sąsiadowi.
+
+    3. Wolność ulepszania utworu i dzielenia się własnymi ulepszeniami ze wszystkimi.
+       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
+
+2. Nikt nie ma prawa unieważnić ani ograniczyć żadnej z powyższych wolności wobec kogokolwiek, w tym ograniczyć tych praw terytorialnie lub geograficznie.
+
+3. Nikt nie ma prawa zezwolić, by w dziełach pochodnych
+   te wolności zostały unieważnione lub ograniczone komukolwiek.
+
+4. Dzieła pochodne muszą jasno wskazywać, czy są powiązane, czy niepowiązane z autorem oryginału,
+   między innymi poprzez wzmiankę o nazwisku autora oryginału oraz ewentualną zmianę nazwy i marki.
+
+5. Utwór jest udostępniany _tak, jak jest_, bez jakiejkolwiek gwarancji wyraźnej lub dorozumianej.
+   Użytkownik korzysta z utworu na własne ryzyko.
+
+---
+
+Copyleft 2025 wiel. Damjes
+
+Ten tekst sam w sobie jest wolny i może być rozpowszechniany na tych samych warunkach.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-DamjesaP – Damjesa Permesilo
-============================
+DamjesaP 2.1 – Damjesa Permesilo
+=================================
 
 Vi havas kvar fundamentajn liberecojn:
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,31 @@
-DamjesaP 2.1 – Damjesa Permesilo
-=================================
+DamjesaP – Damjesa Permesilo v. 2.1
+====================================
 
-Vi havas kvar fundamentajn liberecojn:
+1. Ĉiu uzanto havas kvar fundamentajn liberecojn, kiujn oni povas ĝui sentempe en la tuta mondo:
 
-- La libereco por uzi la programon, por iu ajn celo (libereco 0).
-- La libereco por studi kiel la programo funkcias, kaj ŝanĝi ĝin por viaj bezonoj (libereco 1). Dispono pri la fontkodo de la programo estas antaŭkondiĉo por tio ĉi.
-- La libereco por disdoni kopiojn, do vi povas helpi vian najbaron (libereco 2).
-- La libereco por plibonigi la programon, kaj disdoni viajn plibonigojn al la publiko, por helpi ĉiujn (libereco 3). Atingo al la fontkodo estas antaŭkondiĉo por tio ĉi.
+    0. La libereco uzi la verkon por ajna celo.
 
-Vi ne povas malpermesi ia de supraj liberecoj por iu. Vi ne povas permesi, ke iu malpermesas ia de supraj liberecoj en tia produkto aŭ en produkto, kio baziĝas de tia produkto.
+    1. La libereco studi kiel la verko funkcias kaj ŝanĝi ĝin laŭ siaj bezonoj.
+       Atingebleco de la fonta formo de la verko estas antaŭkondiĉo por tio ĉi.
+
+    2. La libereco distribui kopiojn, por ke la uzanto, ekzemple, povu helpi siajn najbaron.
+
+    3. La libereco plibonigi la verkon kaj kundividi siajn plibonigojn kun ĉiuj.
+       Atingebleco de la fonta formo de la verko estas antaŭkondiĉo por tio ĉi.
+
+2. Neniu rajtas nuligi aŭ limigi iun el la supraj liberecoj por iu ajn, inkluzive per teritoria aŭ geografia limigo de rajtoj.
+
+3. Neniu rajtas permesi, ke tiuj liberecoj estu nuligitaj aŭ limigitaj
+   en derivaĵoj por iu ajn.
+
+4. Derivaĵoj devas klare indiki ĉu ili estas rilataj aŭ ne rilataj kun la originala aŭtoro,
+   interalie per mencio de la nomo de la originala aŭtoro kaj eventuala ŝanĝo de nomo kaj marko.
+
+5. La verko estas provizata _kiel estas_, sen ajna eksplicita aŭ implicita garantio.
+   Uzanto uzas la verkon je sia propra risko.
+
+---
+
+Copyleft 2025 rev. Damjes
+
+Ĉi tiu teksto mem estas libera sub la sama permesilo.

--- a/LICENSE.pl.md
+++ b/LICENSE.pl.md
@@ -1,0 +1,32 @@
+_Ten tekst to oficjalne tłumaczenie na język polski. Obowiązujący jest oryginał w Esperanto (plik `LICENSE.md`)._
+
+# DamjesaP – Licencja Damjesa v. 2.1
+
+1. Każdy użytkownik ma cztery podstawowe wolności, którymi może się cieszyć bezterminowo na całym świecie:
+
+    0. Wolność używania utworu w dowolnym celu.
+
+    1. Wolność badania, jak utwór działa, oraz zmieniania go zgodnie ze swoimi potrzebami.
+       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
+
+    2. Wolność rozpowszechniania kopii, aby użytkownik mógł, na przykład, pomóc swojemu sąsiadowi.
+
+    3. Wolność ulepszania utworu i dzielenia się własnymi ulepszeniami ze wszystkimi.
+       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
+
+2. Nikt nie ma prawa unieważnić ani ograniczyć żadnej z powyższych wolności wobec kogokolwiek, w tym ograniczyć tych praw terytorialnie lub geograficznie.
+
+3. Nikt nie ma prawa zezwolić, by w dziełach pochodnych
+   te wolności zostały unieważnione lub ograniczone komukolwiek.
+
+4. Dzieła pochodne muszą jasno wskazywać, czy są powiązane, czy niepowiązane z autorem oryginału,
+   między innymi poprzez wzmiankę o nazwisku autora oryginału oraz ewentualną zmianę nazwy i marki.
+
+5. Utwór jest udostępniany _tak, jak jest_, bez jakiejkolwiek gwarancji wyraźnej lub dorozumianej.
+   Użytkownik korzysta z utworu na własne ryzyko.
+
+---
+
+Copyleft 2025 wiel. Damjes
+
+Ten tekst sam w sobie jest wolny i może być rozpowszechniany na tych samych warunkach.


### PR DESCRIPTION
## Summary
Updated the DamjesaP license document to version 2.1 with significant restructuring and added an official Polish translation.

## Key Changes

- **Version bump**: Updated from DamjesaP to DamjesaP v. 2.1
- **Restructured license text**: Reorganized the four fundamental freedoms into a numbered list format with improved clarity and formatting
- **Enhanced clarity**: Expanded and refined the language describing each freedom (0-3) with better explanation of source code availability requirements
- **Added new provisions**:
  - Section 2: Explicit prohibition against restricting freedoms territorially or geographically
  - Section 3: Requirement that derivative works maintain these freedoms
  - Section 4: Requirements for derivatives to clearly indicate relationship to original author
  - Section 5: Disclaimer clause (as-is provision with no warranties)
- **Added Polish translation**: Included complete official Polish translation (`DamjesaP – Licencja Damjesa v. 2.1`) with note that the Esperanto original is authoritative
- **Added copyright and copyleft notice**: Included "Copyleft 2025 rev. Damjes" and clarified that the license text itself is free under the same terms

## Notable Details

The license maintains its core philosophy of four fundamental freedoms while adding more explicit legal protections and clarifications. The addition of the Polish translation makes the license more accessible to non-Esperanto speakers while maintaining the Esperanto version as the official reference.

https://claude.ai/code/session_01Kc4p1gzP1NsSziLbxjPMMZ