### PR TITLE
Update DamjesaP license to v2.1 with Polish translation

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,30 @@
-DamjesaP – Damjesa Permesilo
-============================
+# DamjesaP – Damjesa Permesilo v. 2.1
 
-Vi havas kvar fundamentajn liberecojn:
+1. Ĉiu uzanto havas kvar fundamentajn liberecojn, kiujn oni povas ĝui sentempe en la tuta mondo:
 
-- La libereco por uzi la programon, por iu ajn celo (libereco 0).
-- La libereco por studi kiel la programo funkcias, kaj ŝanĝi ĝin por viaj bezonoj (libereco 1). Dispono pri la fontkodo de la programo estas antaŭkondiĉo por tio ĉi.
-- La libereco por disdoni kopiojn, do vi povas helpi vian najbaron (libereco 2).
-- La libereco por plibonigi la programon, kaj disdoni viajn plibonigojn al la publiko, por helpi ĉiujn (libereco 3). Atingo al la fontkodo estas antaŭkondiĉo por tio ĉi.
+    0. La libereco uzi la verkon por ajna celo.
 
-Vi ne povas malpermesi ia de supraj liberecoj por iu. Vi ne povas permesi, ke iu malpermesas ia de supraj liberecoj en tia produkto aŭ en produkto, kio baziĝas de tia produkto.
+    1. La libereco studi kiel la verko funkcias kaj ŝanĝi ĝin laŭ siaj bezonoj.
+       Atingebleco de la fonta formo de la verko estas antaŭkondiĉo por tio ĉi.
+
+    2. La libereco distribui kopiojn, por ke la uzanto, ekzemple, povu helpi siajn najbaron.
+
+    3. La libereco plibonigi la verkon kaj kundividi siajn plibonigojn kun ĉiuj.
+       Atingebleco de la fonta formo de la verko estas antaŭkondiĉo por tio ĉi.
+
+2. Neniu rajtas nuligi aŭ limigi iun el la supraj liberecoj por iu ajn, inkluzive per teritoria aŭ geografia limigo de rajtoj.
+
+3. Neniu rajtas permesi, ke tiuj liberecoj estu nuligitaj aŭ limigitaj
+   en derivaĵoj por iu ajn.
+
+4. Derivaĵoj devas klare indiki ĉu ili estas rilataj aŭ ne rilataj kun la originala aŭtoro,
+   interalie per mencio de la nomo de la originala aŭtoro kaj eventuala ŝanĝo de nomo kaj marko.
+
+5. La verko estas provizata _kiel estas_, sen ajna eksplicita aŭ implicita garantio.
+   Uzanto uzas la verkon je sia propra risko.
+
+---
+
+Copyleft 2025 rev. Damjes
+
+Ĉi tiu teksto mem estas libera sub la sama permesilo.

--- a/LICENSE.pl.md
+++ b/LICENSE.pl.md
@@ -1,0 +1,32 @@
+_Ten tekst to oficjalne tłumaczenie na język polski. Obowiązujący jest oryginał w Esperanto (plik `LICENSE.md`)._
+
+# DamjesaP – Licencja Damjesa v. 2.1
+
+1. Każdy użytkownik ma cztery podstawowe wolności, którymi może się cieszyć bezterminowo na całym świecie:
+
+    0. Wolność używania utworu w dowolnym celu.
+
+    1. Wolność badania, jak utwór działa, oraz zmieniania go zgodnie ze swoimi potrzebami.
+       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
+
+    2. Wolność rozpowszechniania kopii, aby użytkownik mógł, na przykład, pomóc swojemu sąsiadowi.
+
+    3. Wolność ulepszania utworu i dzielenia się własnymi ulepszeniami ze wszystkimi.
+       Dostępność formy źródłowej utworu jest warunkiem koniecznym tej wolności.
+
+2. Nikt nie ma prawa unieważnić ani ograniczyć żadnej z powyższych wolności wobec kogokolwiek, w tym ograniczyć tych praw terytorialnie lub geograficznie.
+
+3. Nikt nie ma prawa zezwolić, by w dziełach pochodnych
+   te wolności zostały unieważnione lub ograniczone komukolwiek.
+
+4. Dzieła pochodne muszą jasno wskazywać, czy są powiązane, czy niepowiązane z autorem oryginału,
+   między innymi poprzez wzmiankę o nazwisku autora oryginału oraz ewentualną zmianę nazwy i marki.
+
+5. Utwór jest udostępniany _tak, jak jest_, bez jakiejkolwiek gwarancji wyraźnej lub dorozumianej.
+   Użytkownik korzysta z utworu na własne ryzyko.
+
+---
+
+Copyleft 2025 wiel. Damjes
+
+Ten tekst sam w sobie jest wolny i może być rozpowszechniany na tych samych warunkach.


### PR DESCRIPTION
## Summary
This PR updates the DamjesaP license to version 2.1 with significant restructuring and clarifications, and adds an official Polish translation.

## Key Changes

- **License restructuring**: Reorganized the license from a bullet-point format into a numbered section structure (5 main sections) for improved clarity and legal precision
- **Enhanced wording**: Refined Esperanto language to be more precise and comprehensive:
  - Changed "programo" (program) to "verko" (work) for broader applicability
  - Expanded freedom descriptions with more detailed conditions
  - Added explicit territorial/geographical rights protection
  - Clarified derivative work requirements regarding attribution and naming
  - Added warranty disclaimer and risk acknowledgment clause
- **New Polish translation**: Added `LICENSE.pl.md` as an official Polish translation with a disclaimer noting that the Esperanto original is authoritative
- **Version bump**: Updated from implicit version to explicit v2.1
- **Copyright update**: Updated copyright year to 2025 and added "Copyleft" attribution

## Notable Details

- The license now explicitly addresses derivative works' obligations regarding author attribution and branding
- Added a comprehensive warranty disclaimer (section 5)
- Polish translation includes a header clarifying it is an official translation with the Esperanto version as the binding reference
- The license text itself is declared as free under the same license terms

https://claude.ai/code/session_01YAcdJWtu8E5WPgLoq43d2U